### PR TITLE
Remove isomorphic-ws, add bin/kaocha

### DIFF
--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,0 +1,2 @@
+#!/bin/sh
+clojure -m kaocha.runner "$@"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "isomorphic-ws": "^4.0.1",
     "ws": "^7.2.1"
   }
 }


### PR DESCRIPTION
Isomorphic-ws is no longer needed for kaocha-cljs.

`bin/kaocha` is part of the kaocha interface, it should be there so people have a uniform way to invoke kaocha.